### PR TITLE
fix(builder): properly inject nixfmt binary into runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ an attrset with the following structure.
 
 ## Additional questions, issues 🗣️
 
-### How can I use a custom version of the `nix` binary?
+### How can I use a custom version of the `nix` or `nixfmt` binary?
 
 If installed via the nix package manager, `flake-parts-builder` will use
 an isolated version of `pkgs.nixVersions.stable` with
@@ -237,6 +237,13 @@ for example
 
 ```bash
 NIX_BIN_PATH=/bin/patched-nix flake-parts-builder init -p +home-manager,shells myNewProject
+```
+
+The same thing works for overriding the `nixfmt` binary using the 
+`NIXFMT_BIN_PATH` environment variable
+
+```bash
+NIX_BIN_PATH=/bin/nixfmt-classic flake-parts-builder init -p +home-manager,shells myNewProject
 ```
 
 ### Why not use `flake.templates` instead?

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The same thing works for overriding the `nixfmt` binary using the
 `NIXFMT_BIN_PATH` environment variable
 
 ```bash
-NIX_BIN_PATH=/bin/nixfmt-classic flake-parts-builder init -p +home-manager,shells myNewProject
+NIXFMT_BIN_PATH=/bin/nixfmt-classic flake-parts-builder init -p +home-manager,shells myNewProject
 ```
 
 ### Why not use `flake.templates` instead?

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       inherit (inputs.nixpkgs) lib;
 
       tsandrini = {
-        email = "tomas.sandrini@seznam.cz";
+        email = "t@tsandrini.sh";
         name = "Tomáš Sandrini";
         github = "tsandrini";
         githubId = 21975189;
@@ -93,6 +93,7 @@
                     rustPlatform,
                     nixfmt-rfc-style,
                     nix,
+                    makeWrapper,
                     tsandrini,
                   }:
                   rustPlatform.buildRustPackage {
@@ -138,17 +139,29 @@
                       cargo doc --no-deps --release
                     '';
 
+                    NIX_BIN_PATH = lib.getExe nix;
+                    NIXFMT_BIN_PATH = lib.getExe nixfmt-rfc-style;
+
                     postInstall = ''
                       mkdir -p $out/doc
                       cp -r target/doc $out/
                     '';
+
+                    nativeBuildInputs = [
+                      makeWrapper
+                    ];
 
                     buildInputs = [
                       nixfmt-rfc-style
                       nix
                     ];
 
-                    NIX_BIN_PATH = "${nix}/bin/nix";
+                    # Just add required binaries to PATH, letting the Rust
+                    # program's which::which handle discovery
+                    postFixup = ''
+                      wrapProgram $out/bin/flake-parts-builder \
+                        --prefix PATH : ${lib.makeBinPath [ nix nixfmt-rfc-style ]}
+                    '';
 
                     meta = with lib; {
                       homepage = "https://github.com/tsandrini/flake-parts-builder";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Overview

<!-- Provide a brief overview of what this PR aims to accomplish. For instance,
is it adding a new configuration, updating an existing one, fixing a bug, or
improving the documentation? -->

Fixes #39 

## Testing

<!-- Describe the testing process for the changes. Include steps to reproduce
any relevant scenarios and the expected outcomes. For example when creating a new
package, test that `nix build` produces the expected binaries/libraries and that
they work as well. Or when adding new NixOS/home-manager modules that you were
able to include them in a NixOS/home-configuration build and that they work.-->

## Dependencies

<!-- List any new dependencies introduced by this PR, or if any existing
dependencies are updated or removed. -->

## Screenshots
<!-- Provide screenshots demonstrating the changes, especially for UI-related
updates (if applicable). -->

## Checklist

<!-- Ensure you've gone through this checklist before submitting your PR. -->

- [x] I have tested the relevant changes locally.
- [x] I have checked that `nix flake check` passes.
- [x] I have ensured my commits follow the project's commits guidelines.
- [x] I have checked that the changes follow a linear history.
- [ ] (If applicable) I have commented any relevant parts of my code.
- [ ] (If applicable) I have added appropriate unit/feature tests.
- [ ] (If applicable) I have updated the documentation accordingly (in English).

## Additional Notes

<!-- Add any other notes, comments, or considerations regarding the PR here. -->

## Summary by Sourcery

Fixes an issue where the `nixfmt` binary was not being properly injected into the runtime environment, and allows users to specify custom paths for the `nix` and `nixfmt` binaries.

Bug Fixes:
- Fixes an issue where the `nixfmt` binary was not being properly injected into the runtime environment.

Enhancements:
- Allows users to specify custom paths for the `nix` and `nixfmt` binaries via the `NIX_BIN_PATH` and `NIXFMT_BIN_PATH` environment variables, respectively.

Build:
- Adds `makeWrapper` as a native build input to properly inject the nixfmt binary into the runtime environment.
- The build process now wraps the `flake-parts-builder` executable to ensure that the `nix` and `nixfmt` binaries are available in the PATH at runtime.

Documentation:
- Adds documentation on how to use a custom version of the `nixfmt` binary.