### PR TITLE
fix(flake): remove lib typo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
 
         mapModules =
           dir: fn:
-          mapFilterAttrs (n: v: v != null && !(lib.hasPrefix "_" n) && !(lib.lib.hasPrefix ".git" n)) (
+          mapFilterAttrs (n: v: v != null && !(lib.hasPrefix "_" n) && !(lib.hasPrefix ".git" n)) (
             n: v:
             let
               path = "${toString dir}/${n}";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Overview

<!-- Provide a brief overview of what this PR aims to accomplish. For instance,
is it adding a new configuration, updating an existing one, fixing a bug, or
improving the documentation? -->

Very simple, you accidently typed lib twice.

## Testing

<!-- Describe the testing process for the changes. Include steps to reproduce
any relevant scenarios and the expected outcomes. For example when creating a new
package, test that `nix build` produces the expected binaries/libraries and that
they work as well. Or when adding new NixOS/home-manager modules that you were
able to include them in a NixOS/home-configuration build and that they work.-->

Added my fork branch to my own flake and loaded the flake in a repl.

## Dependencies

<!-- List any new dependencies introduced by this PR, or if any existing
dependencies are updated or removed. -->

## Screenshots
<!-- Provide screenshots demonstrating the changes, especially for UI-related
updates (if applicable). -->

## Checklist

<!-- Ensure you've gone through this checklist before submitting your PR. -->

- [x] I have tested the relevant changes locally.
- [ ] I have checked that `nix flake check` passes.
- [ ] I have ensured my commits follow the project's commits guidelines.
- [x] I have checked that the changes follow a linear history.
- [ ] (If applicable) I have commented any relevant parts of my code.
- [ ] (If applicable) I have added appropriate unit/feature tests.
- [ ] (If applicable) I have updated the documentation accordingly (in English).

## Additional Notes

<!-- Add any other notes, comments, or considerations regarding the PR here. -->

## Summary by Sourcery

Fix a typo in the flake.nix file by removing a duplicated 'lib.' in a condition.