### PR TITLE
Fix devenv systems dependency

### DIFF
--- a/flake-parts/devenv/meta.nix
+++ b/flake-parts/devenv/meta.nix
@@ -13,6 +13,9 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
+  dependencies = [
+    "systems"
+  ];
   conflicts = [ "shells" ];
   extraTrustedPublicKeys = [ "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=" ];
   extraSubstituters = [ "https://devenv.cachix.org" ];


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Overview

<!-- Provide a brief overview of what this PR aims to accomplish. For instance,
is it adding a new configuration, updating an existing one, fixing a bug, or
improving the documentation? -->

Running the command `flake-parts-builder init -p devenv . && direnv allow` fails
because devenv depends on the systems flake input.

## Testing

<!-- Describe the testing process for the changes. Include steps to reproduce
any relevant scenarios and the expected outcomes. For example when creating a new
package, test that `nix build` produces the expected binaries/libraries and that
they work as well. Or when adding new NixOS/home-manager modules that you were
able to include them in a NixOS/home-configuration build and that they work.-->

No test framework exists.

## Dependencies

<!-- List any new dependencies introduced by this PR, or if any existing
dependencies are updated or removed. -->

## Screenshots

<!-- Provide screenshots demonstrating the changes, especially for UI-related
updates (if applicable). -->

## Checklist

<!-- Ensure you've gone through this checklist before submitting your PR. -->

- [ ] I have tested the relevant changes locally.
- [ ] I have checked that `nix flake check` passes.
- [ ] I have ensured my commits follow the project's commits guidelines.
- [ ] I have checked that the changes follow a linear history.
- [ ] (If applicable) I have commented any relevant parts of my code.
- [ ] (If applicable) I have added appropriate unit/feature tests.
- [ ] (If applicable) I have updated the documentation accordingly (in English).

## Additional Notes

<!-- Add any other notes, comments, or considerations regarding the PR here. -->

The PR does not work because the `inputs` field in the `meta` definition
overrides dependencies, so `systems` is not added to the flake inputs.

## Summary by Sourcery

Bug Fixes:
- Declare `systems` in the `dependencies` field of `flake-parts/devenv/meta.nix` to ensure the flake input is available for `devenv`.